### PR TITLE
Install missing yarn executable in frontend Dockerfile.

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:7
 
+RUN npm i -g yarn
+
 # speed up exit on SIGINT/SIGTERM
 RUN wget -qO /tini https://github.com/krallin/tini/releases/download/v0.14.0/tini
 RUN chmod +x /tini


### PR DESCRIPTION
The frontend image build would fail at `yarn install` step otherwise.

Note: node:7 was resolved to v 7.5. Is yarn maybe installed by default in some other 7.x?